### PR TITLE
Always send the current billing name to Stripe

### DIFF
--- a/templates/payment.php
+++ b/templates/payment.php
@@ -80,7 +80,41 @@
         }
         if(el.id == 'billing_first_name' || el.id == 'billing_last_name')
         {
-            card_name += $(el).val() + ' ';
+            // If the billing first and last name fields were pre-populated (if the user was logged in)
+            // the fields will have values
+            var billingFirstName = $('#billing_first_name').val();
+            var billingLastName = $('#billing_last_name').val();
+
+            // Set the card name from the pre-populated fields
+            card_name = $('#billing_first_name').val() + ' ' + $('#billing_last_name').val();
+
+
+            // If the first name is changed
+            $('#billing_first_name').blur(function () {
+              
+              // update the first name
+              billingFirstName = $(this).val();
+              
+              // update the card name with the new first name
+              card_name = billingFirstName + " " + billingLastName;
+              
+              // Update the hidden Stripe card name input with the new card name
+              $('#stripeCardName').attr('value', card_name);
+            });
+
+
+            // If the last name is changed
+            $('#billing_last_name').blur(function () {
+              
+              // update the last name
+              billingLastName = $('#billing_last_name').val();
+              
+              // update the card name with the new last name
+              card_name = billingFirstName + " " + billingLastName;
+
+              // Update the hidden Stripe card name input with the new card name
+              $('#stripeCardName').attr('value', card_name);
+            });
         }
         
         


### PR DESCRIPTION
This didn't return the concatenated billing name for me `card_name += $(el).val() + ' ';` (Which may have must been something to do with the WooCommerce installation I was working with).

I set the first and last name more verbosely and made sure updated billing details are set as the card name hidden field value.

The code is probably a bit bloated and poor—a results of my tiny js knowledge—but hopefully the intention is good.
