### PR TITLE
Fixing typo that was causing Striper to fail

### DIFF
--- a/templates/payment.php
+++ b/templates/payment.php
@@ -7,7 +7,7 @@
  */
 ?>
 
-<div id="stripe_pub_key" class="hidden" style="display:none" data-publishablekey="<?=$this->publishable_key ?>"> </div>
+<div id="stripe_pub_key" class="hidden" style="display:none" data-publishablekey="<?php echo $this->publishable_key; ?>"> </div>
 <div class="clear"></div>
 <span class='payment-errors required'></span>
 <p class="form-row">


### PR DESCRIPTION
This particular line was causing CC payments to fail - Stripe was returning an error saying that there was whitespace in the key. Switching to this fixes it.
