### PR TITLE
Ability to override payment form template in theme folder

### DIFF
--- a/stripe_gateway.php
+++ b/stripe_gateway.php
@@ -136,7 +136,14 @@ class Striper extends WC_Payment_Gateway
 
     public function payment_fields()
     {
-        include_once('templates/payment.php');
+        if (file_exists(get_stylesheet_directory() . '/striper/payment.php'))
+        {
+          include_once(get_stylesheet_directory() . '/striper/payment.php');
+        }
+        else
+        {
+          include_once('templates/payment.php');
+        }        
     }
 
     protected function send_to_stripe()


### PR DESCRIPTION
The plugin will check in the active theme folder for a `/striper/payment.php` file and include it in preference to the one located in `/templates/payment.php` in the plugin folder. This allows users to customize the layout of the credit card fields without modifying the plugin files.
