### PR TITLE
Use WC `get_option` method rather than WP global

### DIFF
--- a/stripe-gateway.php
+++ b/stripe-gateway.php
@@ -239,10 +239,10 @@ class Striper extends WC_Payment_Gateway
 			$err  = $body['error'];
 		
 			if ($this->logger)
-				$this->logger->add('striper', 'Stripe Error:' . $err['message']);
+				$this->logger->add('striper', 'Stripe Error: ' . $err['message']);
 
-			wc_add_notice(__('Payment error:', 'striper') . $err['message'], 'error');
-        
+			wc_add_notice(__('Payment error: ', 'striper') . $err['message'], 'error');
+        		$this->transactionErrorMessage = $err['message'];
 			return false;
 		}
     }
@@ -379,10 +379,10 @@ function striper_order_status_completed($order_id = null)
       $err  = $body['error'];
 	  
 	  if ($this->logger)
-			$this->logger->add('striper', 'Stripe Error:' . $err['message']);
+			$this->logger->add('striper', 'Stripe Error: ' . $err['message']);
       
-	  wc_add_notice(__('Payment error:', 'striper') . $err['message'], 'error');
-      
+	  wc_add_notice(__('Payment error: ', 'striper') . $err['message'], 'error');
+          $this->transactionErrorMessage = $err['message'];
 	  return null;
     }
    return true;

--- a/stripe-gateway.php
+++ b/stripe-gateway.php
@@ -46,7 +46,7 @@ class Striper extends WC_Payment_Gateway
         $this->testApiKey 		  = $this->get_option('test_api_key');
         $this->liveApiKey 		  = $this->get_option('live_api_key');
         $this->testPublishableKey = $this->get_option('test_publishable_key');
-        $this->livePublishableKey = get_option('live_publishable_key');
+        $this->livePublishableKey = $this->get_option('live_publishable_key');
 		$this->publishable_key    = $this->usesandboxapi ? $this->testPublishableKey : $this->livePublishableKey;
         $this->secret_key         = $this->usesandboxapi ? $this->testApiKey : $this->liveApiKey;
         


### PR DESCRIPTION
The missing `$this->` for setting the `live_publishable_key` for the class causes this plugin to not work for live deployments as it fails to set the key resulting in using an empty string for the live publishable stripe key.

As the mistake was not there for the test keys this led to immense confusion as it worked fine on my test environment and subsequently failed when pushed live.
